### PR TITLE
Remove colons from -e --emoji flag example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ being an extension for interacting with the status on a GitHub profile.
 - `gh user-status set`
 	- `gh user-status set --limited "vacation"` set a status with limited availability
 	- `gh user-status set --expiry 1w "leave me alone"` set with 1 week expiry
-	- `gh user-status set --emoji ":pizza:" "eating lunch"` set with an emoji
+	- `gh user-status set --emoji "pizza" "eating lunch"` set with an emoji
 	- `gh user-status set` clear your status
 - `gh user-status get`
 	- `gh user-status get` see your status


### PR DESCRIPTION
Looks like the latest version uses e.g. `ok` instead of `:ok:` when setting the emoji?

```
$ gh user-status set --emoji ":ok:" "200"
Error: failed to set status. Perhaps try another emoji
Usage:
  user-status set <status> [flags]

Flags:
  -e, --emoji string      Emoji for status (default "thought_balloon")
  -E, --expiry duration   Expire status after this duration
  -h, --help              help for set
  -l, --limited           Indicate limited availability
  -o, --org string        Limit status visibility to an organization
```